### PR TITLE
Fix #1: Add missing module libld-l4.so to modules.list

### DIFF
--- a/checkout_and_build.sh
+++ b/checkout_and_build.sh
@@ -182,6 +182,7 @@ kernel fiasco -serial_esc
 roottask moe rom/hello_world.cfg
 module l4re
 module ned
+module libld-l4.so
 module hello_world.cfg
 module hello_world
 _EOF


### PR DESCRIPTION
### Summary

This PR fixes issue #1 by adding the missing `libld-l4.so` module to the `modules.list` file. The absence of this module was causing runtime errors when launching `hello_world`, specifically:

